### PR TITLE
add 'T: Send' to Send/Sync impls.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,9 @@ impl<T> Drop for QueueSender<T> {
     }
 }
 
-unsafe impl<T> Sync for QueueSender<T> {}
+unsafe impl<T: Send> Sync for QueueSender<T> {}
 
-unsafe impl<T> Send for QueueSender<T> {}
+unsafe impl<T: Send> Send for QueueSender<T> {}
 
 /// A `QueueReceiver` is used to pop previously
 /// pushed items from the queue.
@@ -181,7 +181,7 @@ impl<T> Drop for QueueReceiver<T> {
     }
 }
 
-unsafe impl<T> Send for QueueReceiver<T> {}
+unsafe impl<T: Send> Send for QueueReceiver<T> {}
 
 pub struct Queue;
 


### PR DESCRIPTION
This PR fixes #9.

The `Sync` impl needs `T: Send`, but doesn't need `T: Sync` 
since `QueueSender<T>` merely sends `T` to other threads without providing/applying concurrent access to `T`.
The `Send` impls need `T: Send` bound.

Thank you for reviewing this PR :+1: 